### PR TITLE
fix bug,  exprs is empty when category_id = 0

### DIFF
--- a/denser_retriever/retriever_milvus.py
+++ b/denser_retriever/retriever_milvus.py
@@ -316,7 +316,7 @@ class RetrieverMilvus(Retriever):
                     exprs.append(f"{internal_field} == {unix_time}")
             else:
                 category_id = self.field_cat_to_id[field].get(category_or_date_str)
-                if category_id:
+                if category_id is not None:
                     exprs.append(f"{internal_field}=={category_id}")
         expr_str = " and ".join(exprs)
         search_params = {


### PR DESCRIPTION
fix bug,  exprs is empty when category_id = 0

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/denser_org/denser-retriever/blob/main/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/denser_org/denser-retriever/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
