### PR TITLE
feature Improvement about sentence_transformers(embedding,Reranker)

### DIFF
--- a/denser_retriever/reranker.py
+++ b/denser_retriever/reranker.py
@@ -5,7 +5,7 @@ from sentence_transformers import CrossEncoder
 
 class Reranker:
     def __init__(self, rerank_model: str):
-        self.model = CrossEncoder(rerank_model, max_length=512)
+        self.model = CrossEncoder(rerank_model, trust_remote_code=True, max_length=512)
 
     def rerank(self, query, passages, batch_size, query_id=None):
         passages_copy = copy.deepcopy(passages)
@@ -18,7 +18,7 @@ class Reranker:
 
         for i in range(0, num_passages, batch_size):
             batch = passage_texts[i : i + batch_size]
-            scores = self.model.predict(batch).tolist()
+            scores = self.model.predict(batch, batch_size=batch_size, convert_to_tensor=True).tolist()
 
             for j, passage in enumerate(passages_copy[i : i + batch_size]):
                 score_rerank = scores[j] if isinstance(scores, list) else scores

--- a/denser_retriever/retriever_milvus.py
+++ b/denser_retriever/retriever_milvus.py
@@ -147,12 +147,12 @@ class RetrieverMilvus(Retriever):
             with open(fields_file, "r") as file:
                 self.field_cat_to_id, self.field_id_to_cat = json.load(file)
 
-    def generate_embedding(self, texts, query=False):
+    def generate_embedding(self, texts, batch_size, query=False):
         if query and not self.config.one_model:
-            embeddings = self.model.encode(texts, prompt_name="query")
+            embeddings = self.model.encode(texts, batch_size=batch_size, prompt_name="query")
             # embeddings = self.model.encode(texts, prompt="Represent this sentence for searching relevant passages:")
         else:
-            embeddings = self.model.encode(texts)
+            embeddings = self.model.encode(texts, batch_size=batch_size)
         return embeddings
 
     def ingest(self, doc_or_passage_file, batch_size):
@@ -204,7 +204,7 @@ class RetrieverMilvus(Retriever):
                         fieldss[i].append(-1)
                 record_id += 1
                 if len(batch) == batch_size:
-                    embeddings = self.generate_embedding(batch)
+                    embeddings = self.generate_embedding(batch,batch_size)
                     record = [uids, sources, titles, texts, pids, np.array(embeddings)]
                     record += fieldss
                     try:
@@ -215,7 +215,7 @@ class RetrieverMilvus(Retriever):
                         )
 
                     records_per_file.append(record)
-                    if len(records_per_file) == 1000:
+                    if len(records_per_file) == 100:
                         with open(f"{cache_file}_{record_id}.pkl", "wb") as file:
                             pickle.dump(records_per_file, file)
                         records_per_file = []


### PR DESCRIPTION
## Description

-  Adapt the jinaai/jina-reranker-v2-base-multilingual model for Reranker. refer to [Jinaai discussions in huggingface](https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual/discussions/8#:~:text=of%20Sentence%20Transformers.-,Until,-then%2C%20I%27ve%20added)
-  Modify the predict batch size for sentence_transformers from [32 (default)](https://github.com/UKPLab/sentence-transformers/blob/0ff4e0cd0ab784b1c5b616e14e980b7401f652a8/sentence_transformers/cross_encoder/CrossEncoder.py#L457C1-L458C1) to vector_ingest_passage_bs.(milvus embedding, Reranker)
-  In order to  avoid OOM in  during milvus data ingestion, change the 'len(records_per_file)' parameter for saving files from 1000 to 100.

Thanks, please feel free to make suggestions.

<!-- Add a more detailed description of the changes if needed. -->

## TODO
- [x] make formatting 
- [ ] make test

## Related Issue

NO

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/denser_org/denser-retriever/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/denser_org/denser-retriever/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
